### PR TITLE
Get setProductionDomain and isDevelopment working

### DIFF
--- a/js/util.js
+++ b/js/util.js
@@ -561,9 +561,9 @@ var util = (function () {
         if (!match) {
             if (window.debug) {
                 window.console.warn(
-                    "Detected non-production environment. This function " +
-                    "expects Neptune to be hosted on " +
-                    "www.neptune.org");
+                    "Detected development environment. This function " +
+                    "considers only " + productionDomain + " to be " +
+                    "production.");
             }
             return true;
         }

--- a/js/util.js
+++ b/js/util.js
@@ -557,7 +557,7 @@ var util = (function () {
         if (productionDomain === undefined) {
             throw new Error("production domain not set");
         }
-        var match = window.location.href.contains('//' + productionDomain);
+        var match = window.location.href.includes('//' + productionDomain);
         if (!match) {
             if (window.debug) {
                 window.console.warn(
@@ -852,7 +852,7 @@ var util = (function () {
     };
 
     util.range = function (min, max, step, inclusiveOrExclusive) {
-        if (!['inclusive', 'exclusive'].contains(inclusiveOrExclusive)) {
+        if (!['inclusive', 'exclusive'].includes(inclusiveOrExclusive)) {
             inclusiveOrExclusive = 'exclusive';
         }
 

--- a/js/util.js
+++ b/js/util.js
@@ -540,6 +540,12 @@ var util = (function () {
 
     util.setProductionDomain = function (domain) {
         var urlParser = document.createElement('a');
+
+        // We need to set the protocol before assigning it to href below or else
+        // it'll be treated as a relative path and hostname will prepend with
+        // the current environment's protocol *and* domain.
+        domain = '//' + domain; // shortcut to use current protocol
+
         urlParser.href = domain;
         if (!urlParser.hostname) {
             throw new Error("Invalid domain: " + domain);
@@ -552,8 +558,7 @@ var util = (function () {
             throw new Error("production domain not set");
         }
         var match = window.location.href.contains('//' + productionDomain);
-        // If no matches, .match returns null
-        if (match === null) {
+        if (!match) {
             if (window.debug) {
                 window.console.warn(
                     "Detected non-production environment. This function " +


### PR DESCRIPTION
Fixed a bug in setProductionDomain. Setting `href` property on an `a`
tag requires a protocol to be specified or else it's assumed, when using
`hostname`, that it's a relative path. Prepending the `domain` with `//`
to provide shorthand method of indicating we want to use whatever the
current protocol is.

Also fixed logic in isDevelopment.