### PR TITLE
Hide Qualtrics export tags

### DIFF
--- a/css/qualtrics.css
+++ b/css/qualtrics.css
@@ -1,1 +1,1360 @@
-#audio-toggle-wrapper{display:block;position:absolute;top:20px;right:10px;height:40px;width:150px;border:5px solid;border-color:transparent;background:transparent;padding:3px 17px 2px 3px}.content-spacer #audio-toggle-wrapper{margin-top:30px}#audio-toggle{height:100%;cursor:pointer;background:url("//www.perts.net/static/images/audio-sprite.png") 0 0}#audio-toggle:hover{background-position:0 125px}#audio-toggle.disabled,#audio-toggle.disabled:hover{cursor:auto;background-position:0 100px}#audio-toggle.on{background-position:0 75px}#audio-toggle.on:hover{background-position:0 50px}#audio-toggle.on.disabled,#audio-toggle.on.disabled:hover{background-position:0 25px}.perts-audio-embed{position:absolute;top:-30px;left:-330px}#Buttons #NextButton,#FakeNextButton,#Buttons .perts-button,.perts-button{display:block;margin:0px auto 45px auto;box-shadow:none;background-color:#3faeec;width:280px;padding:12px 3px;font-size:18px;color:#fff;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px;border:0px solid;text-align:center;text-decoration:none;font-weight:300;font-style:normal;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box;font-family:Arial, sans-serif;cursor:pointer;-moz-appearance:none;-webkit-appearance:none}#Buttons #NextButton:hover,#FakeNextButton:hover,#Buttons .perts-button:hover,.perts-button:hover{background-color:#368dbe}#FakeNextButton{cursor:pointer;margin-top:60px}#Buttons #NextButton:active,#Buttons .perts-button:active{top:0px;box-shadow:none}#Buttons #NextButton.disabled-button{background-color:#7bc7f1;cursor:default}#Buttons #NextButton.disabled-button:hover{background-color:#7bc7f1;cursor:default}a#BackButton{position:absolute;top:30px;left:0px;color:#999;font-size:18px;font-family:"din-condensed-web","Arial",sans-serif;font-style:normal;font-weight:400}#main-content a#BackButton{top:0;left:15px}#split-text a#BackButton{left:15px}@media only screen and (max-width: 767px){#split-text a#BackButton{top:0}}a#BackButton:hover{color:#666;cursor:pointer}@media only screen and (max-width: 800px){a#BackButton{left:15px}}#Buttons input#PreviousButton{display:none}.Skin .MC li input.radio{margin-top:8px;margin-right:18px}.Skin .MC input[type="radio"]{position:relative;margin-top:6px;cursor:pointer}.Skin .MC input[type="radio"]:after{content:"";position:absolute;height:20px;width:20px;background-color:white;-moz-border-radius:10px;-webkit-border-radius:10px;border-radius:10px;border:2px solid #666;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}@media only screen and (min-device-width: 768px) and (max-device-width: 1024px){.Skin .MC input[type="radio"]:after{content:none}}.Skin .MC input[type="radio"]:checked:after{background-color:#4593d5;border:2px solid #4593d5}.Skin .MC td input[type="radio"]:after{top:-1px;left:-4px}.Skin .MC li input[type="radio"]:after{top:-2px;left:-2px}.Skin .MC input.checkbox{position:relative;margin:10px 15px}.Skin .MC input.checkbox:after{content:"";position:absolute;top:-4px;left:-6px;height:20px;width:20px;background-color:white;border:2px solid #666;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}@media (min-width: 768px) and (max-width: 1024px){.Skin .MC input.checkbox:after{content:none}}.Skin .MC input.checkbox:checked:after{background-color:#4593d5;border-color:#4593d5}@media screen and (max-width: 500px){.Skin .MC table{display:block}.Skin .MC table tbody,.Skin .MC table tr,.Skin .MC table td{display:block;width:100%}.Skin .MC table td span.LabelWrapper{position:relative;padding-left:45px;cursor:pointer;text-align:left}.Skin .MC table td span.LabelWrapper br{display:none}.Skin .MC table td span.LabelWrapper label{cursor:pointer;display:block}.Skin .MC table td span.LabelWrapper label:after{content:"";position:absolute;height:20px;width:20px;background-color:white;-moz-border-radius:10px;-webkit-border-radius:10px;border-radius:10px;border:2px solid #666;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box;top:-1px;left:10px}.iOS .Skin .MC table td span.LabelWrapper label:after{top:2px}.Skin .MC table td span.LabelWrapper label.q-checked:after{background-color:#4593d5;border-color:#4593d5}.Skin .MC table td.ControlContainer{height:0;visibility:hidden}}#SurveyEngineBody.iOS .Skin .MC input.checkbox::after,#SurveyEngineBody.Android .Skin .MC input.checkbox::after{top:-1px;height:30px;width:30px}#SurveyEngineBody.iOS input.checkbox:checked::after,#SurveyEngineBody.Android input.checkbox:checked::after{content:"";background:#4593d5;top:-1px;left:-1px}#SurveyEngineBody.iOS .Skin .MC input[type="radio"]::after,#SurveyEngineBody.iOS .Skin .MC input[type="radio"]::after,#SurveyEngineBody.Android .Skin .MC input[type="radio"]::after,#SurveyEngineBody.Android .Skin .MC input[type="radio"]::after{height:30px;width:30px;-moz-border-radius:15px;-webkit-border-radius:15px;border-radius:15px}#SurveyEngineBody.iOS .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,#SurveyEngineBody.iOS .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,#SurveyEngineBody.Android .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,#SurveyEngineBody.Android .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody{overflow-x:auto;-webkit-overflow-scrolling:auto;-ms-overflow-style:auto;-ms-overflow-x:auto}#SurveyEngineBody.iOS .Skin .MC input.checkbox::after{left:-1px}#SurveyEngineBody.iOS .Skin .MC td input[type="radio"]::after,#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]::after,#SurveyEngineBody.iOS .Skin .MC td input[type="radio"]:checked:after,#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]:checked:after{top:-3px;left:-6px}#SurveyEngineBody.Android .Skin .MC input.checkbox::after{left:0px}#SurveyEngineBody.Android .Skin .MC td input[type="radio"]::after,#SurveyEngineBody.Android .Skin .MC li input[type="radio"]::after,#SurveyEngineBody.Android .Skin .MC td input[type="radio"]:checked:after,#SurveyEngineBody.Android .Skin .MC li input[type="radio"]:checked:after{top:-3px;left:-6px}.columns{display:block;margin:30px 0}.columns:before,.columns:after{display:table;content:" ";clear:both}.col{display:block;min-height:1px}.col:first-child{padding-right:20px}@media only screen and (max-width: 800px){.col:first-child{padding-right:0}}.col .perts-quote{padding-right:0px}.col.col-4{width:33.33%}.col.col-4.narrow{width:25%}.col.col-8{width:66.67%}.col.col-8.wide{width:75%}.col.col-8.wide.extra-padding{padding-left:60px}@media only screen and (min-width: 800px){.col{float:left}}@media only screen and (max-width: 800px){.col.col-4,.col.col-4.narrow,.col.col-8,.col.col-8.wide{width:100% !important}}.image-block{display:block;margin:30px auto;text-align:center}.image-block .image-block_caption{margin:5px 0px;color:#999}.col-4 .image-block{margin:15px auto;max-width:100%}.col-4 .image-block.image-block--quote{margin:45px auto 0px auto}.col-4 .image-block.image-block--padded{margin:30px auto}.image-block#intro-image{height:150px;width:400px}.image-block#brain-lobes{background-image:url("/static/images/brain-lobes.png");height:680px;width:500px;margin:0px;background-color:#f0f1f2;position:relative}.image-inset-right{float:right;margin-left:20px;margin-top:20px}.select-many{margin:30px 0px;width:100%;text-align:center}.select-many_option{position:relative;display:inline-block;margin:20px 15px;padding:10px;height:260px;width:220px;background-color:#f6f9fb;vertical-align:top;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box;text-align:center}.select-many_option .option-image{height:100%;width:120px;background-repeat:no-repeat;margin:10px auto}.select-many_option:hover{border:5px solid #3faeec;cursor:pointer}.select-many_option.selected{background-color:#c5e7f9}.select-many_option .option-text{font-size:18px;line-height:26px;position:absolute;width:100%;padding:0px 10px;bottom:20px;left:0px;font-weight:300}.select-many_option:hover .option-image{margin-top:5px}.select-many_option:hover .option-text{bottom:15px;padding:0 5px}.select-many_option .option-image#option-1{background-image:url("//www.studentspaths.org/static/images/option-1-fixed.png")}.select-many_option .option-image#option-2{background-image:url("//www.studentspaths.org/static/images/option-2-fixed.png")}.select-many_option .option-image#option-3{background-image:url("//www.studentspaths.org/static/images/option-3-fixed.png")}.smarter-option{display:inline-block;position:relative;width:370px;margin:25px 12px;height:300px;background-color:#eee;overflow:hidden}.smarter-option.smarter-option--1{background-image:url("//www.studentspaths.org/static/images/option-easy-work.png");margin-left:0px}.smarter-option.smarter-option--2{background-image:url("//www.studentspaths.org/static/images/option-hard-work.png");margin-right:0px}.smarter-option:hover .smarter-option_label{top:150px}.smarter-option_label{position:absolute;width:100%;left:0px;top:300px;-moz-transition-property:top,.5s,ease;-o-transition-property:top,.5s,ease;-webkit-transition-property:top,.5s,ease;transition-property:top 0.5s ease;height:150px;background-color:rgba(0,0,0,0.65);color:#fff;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box;padding:20px;font-size:18px;line-height:24px;font-weight:300}.perts-slider-outer{width:94px;height:27px;overflow:hidden;position:relative;float:right;z-index:10}.perts-slider{background:url("http://labs.engageinteractive.co.uk/itoggle/images/itoggle.png") 0 -27px;width:147px;height:27px;margin-left:-53px;cursor:pointer}.perts-slider.disabled{opacity:0.25;filter:alpha(opacity=25);cursor:default}.neuron-part,.brain-lobe{position:absolute;display:block;height:26px;width:26px;-moz-border-radius:16px;-webkit-border-radius:16px;border-radius:16px;background-color:#fff;border:6px solid #3faeec;-moz-box-shadow:0px 0px 6px rgba(0,0,0,0.6);-webkit-box-shadow:0px 0px 6px rgba(0,0,0,0.6);box-shadow:0px 0px 6px rgba(0,0,0,0.6)}.neuron-part:hover,.brain-lobe:hover{background-color:#3faeec;border:6px solid #368dbe}.neuron-part:hover .part-caption,.brain-lobe:hover .part-caption{display:block}.neuron-part .part-caption,.brain-lobe .part-caption{display:none;position:absolute;bottom:20px;width:150px;text-align:center;font-style:bold;background-color:#fff;padding:10px;border:2px solid #999;-moz-border-radius:5px;-webkit-border-radius:5px;border-radius:5px}.neuron-part#neuron-part--cell-body{left:110px;top:330px}.neuron-part#neuron-part--axon{left:290px;top:345px}.neuron-part#neuron-part--dendrites{left:85px;top:250px}.neuron-part .part-caption{left:0px}.brain-lobe#brain-lobe--frontal{left:110px;top:230px}.brain-lobe#brain-lobe--frontal .part-caption{right:-55px}.brain-lobe#brain-lobe--temporal{left:260px;top:330px}.brain-lobe#brain-lobe--occipital{left:415px;top:300px}.brain-lobe#brain-lobe--parietal{left:300px;top:210px}.brain-lobe .part-caption{right:0px}.perts-quote{display:block;width:100%;position:relative;margin:30px 0px 30px -30px;border-left:4px solid #3faeec;padding:10px 0px 10px 30px;font-weight:300}.perts-quote:before{display:block;content:"";width:32px;height:36px;position:absolute;top:0px;left:-29px;background-image:url("/static/images/perts-quote-mark.png");background-repeat:no-repeat}.perts-quote.perts-quote--light{padding:0px 0px 0px 20px;margin:20px 0px 20px -20px}.perts-quote.perts-quote--light:before{display:none}.perts-quote.perts-quote--light .perts-quote_credit{font-size:18px;margin-top:15px;color:#4593d5;font-weight:500}.perts-quote_body{font-size:21px;color:#666;line-height:32px;font-style:italic}.perts-quote_credit{font-size:21px;margin-top:30px;color:#4593d5;font-weight:500}.perts-quote_credit.credit--top{margin-top:0px;margin-bottom:20px}html #SurveyEngineBody{background:none;background-color:#e3e3e3;font-family:"museo-sans","Arial",sans-serif;color:#333}.SkinInner{width:100%;background-color:#fff;margin:0px}.hidden-label{visibility:hidden;height:0}.Skin{background-color:#fff}.Skin .Separator{margin:0;background-color:transparent}.Skin .Separator ~ .Separator{background-color:transparent}.Skin #Logo,.Skin #PushStickyFooter,.Skin #Plug{display:none !important}.Skin #Plug{background-color:#e3e3e3;position:absolute;left:-9999px}.Skin #Header{position:relative;display:block;padding:0px;height:80px;background-color:#3faeec}.Skin #Footer{background-color:#e3e3e3;height:80px}.Skin #Footer .foot-text{padding-top:26px;text-align:center;font-family:"din-condensed-web","Arial",sans-serif;font-style:normal;font-weight:400;font-size:18px;color:#999}.Skin div#Questions{padding:0px;min-height:400px;overflow:initial}.Skin .QuestionOuter{padding:0px;overflow-x:auto;-ms-overflow-x:auto;-ms-overflow-style:auto}.Skin .QuestionOuter .Inner{padding:0px;overflow-x:hidden}.Skin #ProgressBar{display:none}.Skin .QuestionText{padding:0;line-height:normal}.Skin .QuestionBody,.Skin .MC .QuestionText,.Skin .TE .QuestionText,.Skin .Matrix .QuestionText{display:block;width:770px;margin:0 auto;padding:0;position:relative}@media only screen and (max-width: 800px){.Skin .QuestionBody,.Skin .MC .QuestionText,.Skin .TE .QuestionText,.Skin .Matrix .QuestionText{width:100%;padding:0px 15px;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}}.Skin .Matrix caption.QuestionText{display:none}.Skin .QuestionText{margin:0px}.Skin .QuestionBody table.ChoiceStructure.narrow-table{width:300px;margin-top:25px}.Skin .QuestionBody table.ChoiceStructure.narrow-table td{padding:12px 0}.Skin .MC .QuestionBody{margin:20px auto 25px auto}.Skin .MC .QuestionBody .LabelWrapper label{vertical-align:middle}.Skin .MC .QuestionText{font-weight:300;font-size:21px;color:#333}.Skin .MC table{margin-bottom:55px}.Skin .MC input.TextEntryBox.InputText{left:0px;margin:5px 0px 15px 0px}.Skin .ML *,.Skin .SL *{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}.Skin .ML .ChoiceStructure,.Skin .SL .ChoiceStructure.ChoiceStructureStyled{background-color:#3faeec;padding:35px 6px 6px 6px;margin:30px 0px;position:relative}.Skin .ML .ChoiceStructure textarea,.Skin .SL .ChoiceStructure.ChoiceStructureStyled input{width:100% !important;height:250px !important;border:0;outline:0;padding:15px;font-size:21px;font-weight:300;color:#333;line-height:28px;background-color:#fff;-moz-border-radius:0;-webkit-border-radius:0;border-radius:0}.Skin .SL .ChoiceStructure.ChoiceStructureStyled input{height:50px !important;margin:0px}.Skin h2{font-size:20px;line-height:1em}.Skin p{margin:25px 0}li span.LabelWrapper{font-weight:300;font-size:21px;color:#333}table span.LabelWrapper{font-weight:500;font-size:15px;color:#333;padding:0px 10px;margin:0;display:block}.open-response_header{position:absolute;top:12px;left:10px;color:#fff}#section-header{text-align:center;padding:0px 0px 45px 0;margin-top:30px;color:#999;font-size:18px;font-family:"din-condensed-web","Arial",sans-serif;font-style:normal;font-weight:400}.Skin h1,.Skin #title-text{color:#4593d5;font-size:24px;margin-bottom:30px;font-weight:700}.Skin p{font-size:21px;line-height:30px;margin:15px 0px;font-weight:300}.callout-text{font-size:21px;line-height:30px;font-style:italic;color:#4593d5;margin:30px 0px;font-weight:500}.instruction-text{font-size:18px;color:#999;font-style:italic;margin-bottom:25px}.footnote-text{font-size:14px;color:#999;margin-bottom:25px}#main-content *,#split-page *,#splash-page *{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}#main-content,#splash-page{display:block;width:800px;padding:0px 15px;margin:0 auto 20px auto;max-width:100%;position:relative;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}#splash-page{margin:100px auto 20px auto;text-align:center}#splash-page h1{font-size:32px}#split-page{display:block;width:1000px;margin:0px auto;position:relative;max-width:100%;padding:0 0 0 15px}#split-page:before,#split-page:after{display:table;content:" ";clear:both}#split-text,#split-image{min-height:1px;position:relative;float:left;vertical-align:top;max-width:100%;width:50%}#split-text{padding:0px 30px 0 0;position:relative}#split-image{height:680px;overflow:hidden}#split-image .image-block{margin:0px}#split-image .image-caption{position:absolute;text-align:center;bottom:0px;width:100%;height:95px;color:#999;font-size:18px;font-style:italic}@media only screen and (max-width: 767px){#split-page{padding:0}#split-text,#split-image{display:block;float:none;width:100%}#split-text{padding:0 15px}}@media (max-width: 500px){.Skin .QuestionBody .ControlContainer{display:none}}.hidden-container.hidden-container--hidden{display:none}.Skin ul.perts-bullets,.Skin ol.perts-bullets{margin-top:20px;margin-bottom:20px}.Skin ul.perts-bullets li,.Skin ol.perts-bullets li{font-size:21px;line-height:30px;color:#666;list-style:none;margin-bottom:3px;font-weight:300;position:relative}.Skin ul.perts-bullets,.Skin ul.perts-bullets li,.Skin .QuestionText ul.perts-bullets,.Skin .QuestionText ul.perts-bullets li{list-style-type:none;position:relative}.Skin ul.perts-bullets li:before{content:"";height:12px;width:12px;background-color:#3faeec;-moz-border-radius:6px;-webkit-border-radius:6px;border-radius:6px;position:absolute;display:block;margin-top:8px;left:-30px}.Skin .open-response{background-color:#3faeec;margin:20px 0px;padding:15px}.Skin .open-response .open-response_header{color:#fff;padding-bottom:15px}.Skin .open-response textarea.open-response_input{width:100%;height:250px;border:0;outline:0;padding:15px;font-size:21px;font-weight:300;color:#333;line-height:28px;background-color:#fff;-moz-border-radius:0;-webkit-border-radius:0;border-radius:0}.Skin input.short-form,.Skin input[type="TEXT"]{border-style:none;border:1px solid #ccc;font-size:21px;font-weight:300;padding:10px 15px;margin:0px;width:100%;border:0;outline:0;background-color:#fff;-moz-border-radius:0;-webkit-border-radius:0;border-radius:0}.Skin input[type="TEXT"]{margin-bottom:20px;-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}.Skin .MC input[type="TEXT"],.Skin .SL input[type="TEXT"]{border:1px solid #ccc}.QuestionOuter.Timing{display:none}@media only screen and (max-device-width: 1024px) and (min-device-width: 768px){html #SurveyEngineBody.iOS .Skin .SkinInner,html #SurveyEngineBody.Android .Skin .SkinInner{max-width:100%}}#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]::before{top:-4px;left:-4px}#SurveyEngineBody.iOS .Skin .MC li input[type="checkbox"]::before,#SurveyEngineBody.iOS .Skin .MC li input[type="checkbox"]:checked::before{top:-2px}#SurveyEngineBody.iOS .Skin .MC .QuestionBody .LabelWrapper label,#SurveyEngineBody.Android .Skin .MC .QuestionBody .LabelWrapper label{width:70%;margin-left:10px}fieldset{min-width:0}@-moz-document url-prefix(){fieldset{display:table-cell}}
+/* Basic setup and formatting */
+/* Audio toggle in header (default is OFF) */
+/* line 2, ../sass/_audio.scss */
+#audio-toggle-wrapper {
+  display: block;
+  position: absolute;
+  top: 20px;
+  right: 10px;
+  height: 40px;
+  width: 150px;
+  border: 5px solid;
+  border-color: transparent;
+  background: transparent;
+  padding: 3px 17px 2px 3px;
+}
+
+/* line 15, ../sass/_audio.scss */
+.content-spacer #audio-toggle-wrapper {
+  margin-top: 30px;
+}
+
+/* line 19, ../sass/_audio.scss */
+#audio-toggle {
+  height: 100%;
+  cursor: pointer;
+  background: url("//www.perts.net/static/images/audio-sprite.png") 0 0;
+}
+/* line 24, ../sass/_audio.scss */
+#audio-toggle:hover {
+  background-position: 0 125px;
+}
+/* line 28, ../sass/_audio.scss */
+#audio-toggle.disabled, #audio-toggle.disabled:hover {
+  cursor: auto;
+  background-position: 0 100px;
+}
+/* line 34, ../sass/_audio.scss */
+#audio-toggle.on {
+  background-position: 0 75px;
+}
+/* line 37, ../sass/_audio.scss */
+#audio-toggle.on:hover {
+  background-position: 0 50px;
+}
+/* line 41, ../sass/_audio.scss */
+#audio-toggle.on.disabled, #audio-toggle.on.disabled:hover {
+  background-position: 0 25px;
+}
+
+/* On browsers which use the (visible) embedded media player, move it */
+/* outside the viewport. Giving it display: none; will break it. */
+/* line 50, ../sass/_audio.scss */
+.perts-audio-embed {
+  position: absolute;
+  /* Player is normally 320 x 22 px. This positions it offscreen. */
+  top: -30px;
+  left: -330px;
+}
+
+/* Buttons - Next and Back */
+/* For typical re-styling of next button. */
+/* line 4, ../sass/_buttons.scss */
+#Buttons #NextButton,
+#FakeNextButton,
+#Buttons .perts-button,
+.perts-button {
+  display: block;
+  margin: 0px auto 45px auto;
+  box-shadow: none;
+  background-color: #3faeec;
+  width: 280px;
+  padding: 12px 3px;
+  font-size: 18px;
+  color: #fff;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+  border: 0px solid;
+  text-align: center;
+  text-decoration: none;
+  font-weight: 300;
+  font-style: normal;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  font-family: Arial, sans-serif;
+  cursor: pointer;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+}
+/* line 32, ../sass/_buttons.scss */
+#Buttons #NextButton:hover,
+#FakeNextButton:hover,
+#Buttons .perts-button:hover,
+.perts-button:hover {
+  background-color: #368dbe;
+}
+
+/* line 37, ../sass/_buttons.scss */
+#FakeNextButton {
+  cursor: pointer;
+  margin-top: 60px;
+}
+
+/* line 42, ../sass/_buttons.scss */
+#Buttons #NextButton:active,
+#Buttons .perts-button:active {
+  top: 0px;
+  box-shadow: none;
+}
+
+/* line 48, ../sass/_buttons.scss */
+#Buttons #NextButton.disabled-button {
+  background-color: #7bc7f1;
+  cursor: default;
+}
+
+/* line 53, ../sass/_buttons.scss */
+#Buttons #NextButton.disabled-button:hover {
+  background-color: #7bc7f1;
+  cursor: default;
+}
+
+/* line 58, ../sass/_buttons.scss */
+a#BackButton {
+  position: absolute;
+  top: 30px;
+  left: 0px;
+  color: #999;
+  font-size: 18px;
+  font-family: "din-condensed-web", "Arial", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+}
+/* line 68, ../sass/_buttons.scss */
+#main-content a#BackButton {
+  top: 0;
+  left: 15px;
+}
+/* line 73, ../sass/_buttons.scss */
+#split-text a#BackButton {
+  left: 15px;
+}
+@media only screen and (max-width: 767px) {
+  /* line 73, ../sass/_buttons.scss */
+  #split-text a#BackButton {
+    top: 0;
+  }
+}
+/* line 81, ../sass/_buttons.scss */
+a#BackButton:hover {
+  color: #666;
+  cursor: pointer;
+}
+@media only screen and (max-width: 800px) {
+  /* line 58, ../sass/_buttons.scss */
+  a#BackButton {
+    left: 15px;
+  }
+}
+
+/* line 91, ../sass/_buttons.scss */
+#Buttons input#PreviousButton {
+  display: none;
+}
+
+/* line 5, ../sass/_checkbox-radio.scss */
+.Skin .MC li input.radio {
+  margin-top: 8px;
+  margin-right: 18px;
+}
+/* line 10, ../sass/_checkbox-radio.scss */
+.Skin .MC input[type="radio"] {
+  position: relative;
+  margin-top: 6px;
+  cursor: pointer;
+}
+/* line 15, ../sass/_checkbox-radio.scss */
+.Skin .MC input[type="radio"]:after {
+  content: "";
+  position: absolute;
+  height: 20px;
+  width: 20px;
+  background-color: white;
+  -moz-border-radius: 10px;
+  -webkit-border-radius: 10px;
+  border-radius: 10px;
+  border: 2px solid #666;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+@media only screen and (min-device-width: 768px) and (max-device-width: 1024px) {
+  /* line 15, ../sass/_checkbox-radio.scss */
+  .Skin .MC input[type="radio"]:after {
+    content: none;
+  }
+}
+/* line 31, ../sass/_checkbox-radio.scss */
+.Skin .MC input[type="radio"]:checked:after {
+  background-color: #4593d5;
+  border: 2px solid #4593d5;
+}
+/* line 37, ../sass/_checkbox-radio.scss */
+.Skin .MC td input[type="radio"]:after {
+  top: -1px;
+  left: -4px;
+}
+/* line 42, ../sass/_checkbox-radio.scss */
+.Skin .MC li input[type="radio"]:after {
+  top: -2px;
+  left: -2px;
+}
+/* line 47, ../sass/_checkbox-radio.scss */
+.Skin .MC input.checkbox {
+  position: relative;
+  margin: 10px 15px;
+}
+/* line 51, ../sass/_checkbox-radio.scss */
+.Skin .MC input.checkbox:after {
+  content: "";
+  position: absolute;
+  top: -4px;
+  left: -6px;
+  height: 20px;
+  width: 20px;
+  background-color: white;
+  border: 2px solid #666;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+  /* line 51, ../sass/_checkbox-radio.scss */
+  .Skin .MC input.checkbox:after {
+    content: none;
+  }
+}
+/* line 67, ../sass/_checkbox-radio.scss */
+.Skin .MC input.checkbox:checked:after {
+  background-color: #4593d5;
+  border-color: #4593d5;
+}
+@media screen and (max-width: 500px) {
+  /* line 77, ../sass/_checkbox-radio.scss */
+  .Skin .MC table {
+    display: block;
+  }
+  /* line 81, ../sass/_checkbox-radio.scss */
+  .Skin .MC table tbody,
+  .Skin .MC table tr,
+  .Skin .MC table td {
+    display: block;
+    width: 100%;
+  }
+  /* line 89, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td span.LabelWrapper {
+    position: relative;
+    padding-left: 45px;
+    cursor: pointer;
+    text-align: left;
+  }
+  /* line 95, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td span.LabelWrapper br {
+    display: none;
+  }
+  /* line 99, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td span.LabelWrapper label {
+    cursor: pointer;
+    display: block;
+  }
+  /* line 103, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td span.LabelWrapper label:after {
+    content: "";
+    position: absolute;
+    height: 20px;
+    width: 20px;
+    background-color: white;
+    -moz-border-radius: 10px;
+    -webkit-border-radius: 10px;
+    border-radius: 10px;
+    border: 2px solid #666;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    top: -1px;
+    left: 10px;
+  }
+  /* line 115, ../sass/_checkbox-radio.scss */
+  .iOS .Skin .MC table td span.LabelWrapper label:after {
+    top: 2px;
+  }
+  /* line 120, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td span.LabelWrapper label.q-checked:after {
+    background-color: #4593d5;
+    border-color: #4593d5;
+  }
+  /* line 130, ../sass/_checkbox-radio.scss */
+  .Skin .MC table td.ControlContainer {
+    height: 0;
+    visibility: hidden;
+  }
+}
+
+/* line 140, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS,
+#SurveyEngineBody.Android {
+  /* Mobile controls are bigger, so we need to adjust the ::after bits (which */
+  /* skin the native controls by floating over them). */
+  /* Qualtrics tries to put in a weird checkmark thingy in iPads. Kill it. */
+  /* Allows for scrolling MC questions on mobile devices */
+}
+/* line 145, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS .Skin .MC input.checkbox::after,
+#SurveyEngineBody.Android .Skin .MC input.checkbox::after {
+  top: -1px;
+  height: 30px;
+  width: 30px;
+}
+/* line 152, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS input.checkbox:checked::after,
+#SurveyEngineBody.Android input.checkbox:checked::after {
+  content: "";
+  background: #4593d5;
+  /* Need to override Qualtrics Base styles */
+  top: -1px;
+  left: -1px;
+}
+/* line 160, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS .Skin .MC input[type="radio"]::after,
+#SurveyEngineBody.iOS .Skin .MC input[type="radio"]::after,
+#SurveyEngineBody.Android .Skin .MC input[type="radio"]::after,
+#SurveyEngineBody.Android .Skin .MC input[type="radio"]::after {
+  height: 30px;
+  width: 30px;
+  -moz-border-radius: 15px;
+  -webkit-border-radius: 15px;
+  border-radius: 15px;
+}
+/* line 168, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,
+#SurveyEngineBody.iOS .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,
+#SurveyEngineBody.Android .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody,
+#SurveyEngineBody.Android .Skin #Questions .QuestionOuter.MC fieldset .QuestionBody {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: auto;
+  -ms-overflow-style: auto;
+  -ms-overflow-x: auto;
+}
+
+/* line 178, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS .Skin .MC input.checkbox::after {
+  left: -1px;
+}
+/* line 183, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.iOS .Skin .MC td input[type="radio"]::after,
+#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]::after,
+#SurveyEngineBody.iOS .Skin .MC td input[type="radio"]:checked:after,
+#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]:checked:after {
+  top: -3px;
+  left: -6px;
+}
+
+/* line 193, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.Android .Skin .MC input.checkbox::after {
+  left: 0px;
+}
+/* line 197, ../sass/_checkbox-radio.scss */
+#SurveyEngineBody.Android .Skin .MC td input[type="radio"]::after,
+#SurveyEngineBody.Android .Skin .MC li input[type="radio"]::after,
+#SurveyEngineBody.Android .Skin .MC td input[type="radio"]:checked:after,
+#SurveyEngineBody.Android .Skin .MC li input[type="radio"]:checked:after {
+  top: -3px;
+  left: -6px;
+}
+
+/* Formatting multiple columns with fluid sizing */
+/* line 3, ../sass/_columns.scss */
+.columns {
+  display: block;
+  margin: 30px 0;
+}
+/* line 7, ../sass/_columns.scss */
+.columns:before, .columns:after {
+  display: table;
+  content: " ";
+  clear: both;
+}
+
+/* line 15, ../sass/_columns.scss */
+.col {
+  display: block;
+  min-height: 1px;
+}
+/* line 19, ../sass/_columns.scss */
+.col:first-child {
+  padding-right: 20px;
+}
+@media only screen and (max-width: 800px) {
+  /* line 19, ../sass/_columns.scss */
+  .col:first-child {
+    padding-right: 0;
+  }
+}
+/* line 27, ../sass/_columns.scss */
+.col .perts-quote {
+  padding-right: 0px;
+}
+/* line 31, ../sass/_columns.scss */
+.col.col-4 {
+  width: 33.33%;
+}
+/* line 34, ../sass/_columns.scss */
+.col.col-4.narrow {
+  width: 25%;
+}
+/* line 37, ../sass/_columns.scss */
+.col.col-8 {
+  width: 66.67%;
+}
+/* line 40, ../sass/_columns.scss */
+.col.col-8.wide {
+  width: 75%;
+}
+/* line 43, ../sass/_columns.scss */
+.col.col-8.wide.extra-padding {
+  padding-left: 60px;
+}
+@media only screen and (min-width: 800px) {
+  /* line 15, ../sass/_columns.scss */
+  .col {
+    float: left;
+  }
+}
+@media only screen and (max-width: 800px) {
+  /* line 52, ../sass/_columns.scss */
+  .col.col-4, .col.col-4.narrow, .col.col-8, .col.col-8.wide {
+    width: 100% !important;
+  }
+}
+
+/* Image blocks */
+/* line 3, ../sass/_images.scss */
+.image-block {
+  display: block;
+  margin: 30px auto;
+  text-align: center;
+}
+/* line 8, ../sass/_images.scss */
+.image-block .image-block_caption {
+  margin: 5px 0px;
+  color: #999;
+}
+/* line 13, ../sass/_images.scss */
+.col-4 .image-block {
+  margin: 15px auto;
+  max-width: 100%;
+}
+/* line 17, ../sass/_images.scss */
+.col-4 .image-block.image-block--quote {
+  margin: 45px auto 0px auto;
+}
+/* line 21, ../sass/_images.scss */
+.col-4 .image-block.image-block--padded {
+  margin: 30px auto;
+}
+/* line 26, ../sass/_images.scss */
+.image-block#intro-image {
+  height: 150px;
+  width: 400px;
+}
+/* line 31, ../sass/_images.scss */
+.image-block#brain-lobes {
+  background-image: url("/static/images/brain-lobes.png");
+  height: 680px;
+  width: 500px;
+  margin: 0px;
+  background-color: #f0f1f2;
+  position: relative;
+}
+
+/* Image insets */
+/* line 43, ../sass/_images.scss */
+.image-inset-right {
+  float: right;
+  margin-left: 20px;
+  margin-top: 20px;
+}
+
+/* Custom input - select many */
+/* line 3, ../sass/_interactive-elements.scss */
+.select-many {
+  margin: 30px 0px;
+  width: 100%;
+  text-align: center;
+}
+
+/* line 9, ../sass/_interactive-elements.scss */
+.select-many_option {
+  position: relative;
+  display: inline-block;
+  margin: 20px 15px;
+  padding: 10px;
+  height: 260px;
+  width: 220px;
+  background-color: #f6f9fb;
+  vertical-align: top;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  text-align: center;
+}
+/* line 21, ../sass/_interactive-elements.scss */
+.select-many_option .option-image {
+  height: 100%;
+  width: 120px;
+  background-repeat: no-repeat;
+  margin: 10px auto;
+}
+/* line 28, ../sass/_interactive-elements.scss */
+.select-many_option:hover {
+  border: 5px solid #3faeec;
+  cursor: pointer;
+}
+/* line 33, ../sass/_interactive-elements.scss */
+.select-many_option.selected {
+  background-color: #c5e7f9;
+}
+/* line 37, ../sass/_interactive-elements.scss */
+.select-many_option .option-text {
+  font-size: 18px;
+  line-height: 26px;
+  position: absolute;
+  width: 100%;
+  padding: 0px 10px;
+  bottom: 20px;
+  left: 0px;
+  font-weight: 300;
+}
+/* line 49, ../sass/_interactive-elements.scss */
+.select-many_option:hover .option-image {
+  margin-top: 5px;
+}
+/* line 53, ../sass/_interactive-elements.scss */
+.select-many_option:hover .option-text {
+  bottom: 15px;
+  /* There's a 5px border on hover, so shrink padding by matching */
+  /* amount to avoid content wiggle. */
+  padding: 0 5px;
+}
+/* line 61, ../sass/_interactive-elements.scss */
+.select-many_option .option-image#option-1 {
+  background-image: url("//www.studentspaths.org/static/images/option-1-fixed.png");
+}
+/* line 64, ../sass/_interactive-elements.scss */
+.select-many_option .option-image#option-2 {
+  background-image: url("//www.studentspaths.org/static/images/option-2-fixed.png");
+}
+/* line 67, ../sass/_interactive-elements.scss */
+.select-many_option .option-image#option-3 {
+  background-image: url("//www.studentspaths.org/static/images/option-3-fixed.png");
+}
+
+/* line 72, ../sass/_interactive-elements.scss */
+.smarter-option {
+  display: inline-block;
+  position: relative;
+  width: 370px;
+  margin: 25px 12px;
+  height: 300px;
+  background-color: #eee;
+  overflow: hidden;
+}
+/* line 81, ../sass/_interactive-elements.scss */
+.smarter-option.smarter-option--1 {
+  background-image: url("//www.studentspaths.org/static/images/option-easy-work.png");
+  margin-left: 0px;
+}
+/* line 86, ../sass/_interactive-elements.scss */
+.smarter-option.smarter-option--2 {
+  background-image: url("//www.studentspaths.org/static/images/option-hard-work.png");
+  margin-right: 0px;
+}
+/* line 91, ../sass/_interactive-elements.scss */
+.smarter-option:hover .smarter-option_label {
+  top: 150px;
+}
+
+/* line 96, ../sass/_interactive-elements.scss */
+.smarter-option_label {
+  position: absolute;
+  width: 100%;
+  left: 0px;
+  top: 300px;
+  -moz-transition-property: top, 0.5s, ease;
+  -o-transition-property: top, 0.5s, ease;
+  -webkit-transition-property: top, 0.5s, ease;
+  transition-property: top 0.5s ease;
+  height: 150px;
+  background-color: rgba(0, 0, 0, 0.65);
+  color: #fff;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 20px;
+  font-size: 18px;
+  line-height: 24px;
+  font-weight: 300;
+}
+
+/* Slider toggle */
+/* line 114, ../sass/_interactive-elements.scss */
+.perts-slider-outer {
+  width: 94px;
+  height: 27px;
+  overflow: hidden;
+  position: relative;
+  float: right;
+  z-index: 10;
+}
+
+/* line 123, ../sass/_interactive-elements.scss */
+.perts-slider {
+  background: url("http://labs.engageinteractive.co.uk/itoggle/images/itoggle.png") 0 -27px;
+  width: 147px;
+  height: 27px;
+  margin-left: -53px;
+  /* "off" state */
+  cursor: pointer;
+}
+/* line 130, ../sass/_interactive-elements.scss */
+.perts-slider.disabled {
+  opacity: 0.25;
+  filter: alpha(opacity=25);
+  /* For IE8 and earlier */
+  cursor: default;
+}
+
+/* Neuron interaction */
+/* line 139, ../sass/_interactive-elements.scss */
+.neuron-part, .brain-lobe {
+  position: absolute;
+  display: block;
+  height: 26px;
+  width: 26px;
+  -moz-border-radius: 16px;
+  -webkit-border-radius: 16px;
+  border-radius: 16px;
+  background-color: #fff;
+  border: 6px solid #3faeec;
+  -moz-box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.6);
+  -webkit-box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.6);
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.6);
+}
+/* line 149, ../sass/_interactive-elements.scss */
+.neuron-part:hover, .brain-lobe:hover {
+  background-color: #3faeec;
+  border: 6px solid #368dbe;
+}
+/* line 153, ../sass/_interactive-elements.scss */
+.neuron-part:hover .part-caption, .brain-lobe:hover .part-caption {
+  display: block;
+}
+/* line 158, ../sass/_interactive-elements.scss */
+.neuron-part .part-caption, .brain-lobe .part-caption {
+  display: none;
+  position: absolute;
+  bottom: 20px;
+  width: 150px;
+  text-align: center;
+  font-style: bold;
+  background-color: #fff;
+  padding: 10px;
+  border: 2px solid #999;
+  -moz-border-radius: 5px;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+}
+
+/* line 174, ../sass/_interactive-elements.scss */
+.neuron-part#neuron-part--cell-body {
+  left: 110px;
+  top: 330px;
+}
+/* line 179, ../sass/_interactive-elements.scss */
+.neuron-part#neuron-part--axon {
+  left: 290px;
+  top: 345px;
+}
+/* line 184, ../sass/_interactive-elements.scss */
+.neuron-part#neuron-part--dendrites {
+  left: 85px;
+  top: 250px;
+}
+/* line 189, ../sass/_interactive-elements.scss */
+.neuron-part .part-caption {
+  left: 0px;
+}
+
+/* line 196, ../sass/_interactive-elements.scss */
+.brain-lobe#brain-lobe--frontal {
+  left: 110px;
+  top: 230px;
+}
+/* line 201, ../sass/_interactive-elements.scss */
+.brain-lobe#brain-lobe--frontal .part-caption {
+  right: -55px;
+}
+/* line 205, ../sass/_interactive-elements.scss */
+.brain-lobe#brain-lobe--temporal {
+  left: 260px;
+  top: 330px;
+}
+/* line 210, ../sass/_interactive-elements.scss */
+.brain-lobe#brain-lobe--occipital {
+  left: 415px;
+  top: 300px;
+}
+/* line 215, ../sass/_interactive-elements.scss */
+.brain-lobe#brain-lobe--parietal {
+  left: 300px;
+  top: 210px;
+}
+/* line 220, ../sass/_interactive-elements.scss */
+.brain-lobe .part-caption {
+  right: 0px;
+}
+
+/* PERTS Quotes! */
+/* line 3, ../sass/_quotes.scss */
+.perts-quote {
+  display: block;
+  width: 100%;
+  position: relative;
+  margin: 30px 0px 30px -30px;
+  border-left: 4px solid #3faeec;
+  padding: 10px 0px 10px 30px;
+  font-weight: 300;
+}
+/* line 12, ../sass/_quotes.scss */
+.perts-quote:before {
+  display: block;
+  content: "";
+  width: 32px;
+  height: 36px;
+  position: absolute;
+  top: 0px;
+  left: -29px;
+  background-image: url("/static/images/perts-quote-mark.png");
+  background-repeat: no-repeat;
+}
+/* line 24, ../sass/_quotes.scss */
+.perts-quote.perts-quote--light {
+  padding: 0px 0px 0px 20px;
+  margin: 20px 0px 20px -20px;
+}
+/* line 28, ../sass/_quotes.scss */
+.perts-quote.perts-quote--light:before {
+  display: none;
+}
+/* line 32, ../sass/_quotes.scss */
+.perts-quote.perts-quote--light .perts-quote_credit {
+  font-size: 18px;
+  margin-top: 15px;
+  color: #4593d5;
+  font-weight: 500;
+}
+
+/* line 41, ../sass/_quotes.scss */
+.perts-quote_body {
+  font-size: 21px;
+  color: #666;
+  line-height: 32px;
+  font-style: italic;
+}
+
+/* line 48, ../sass/_quotes.scss */
+.perts-quote_credit {
+  font-size: 21px;
+  margin-top: 30px;
+  color: #4593d5;
+  font-weight: 500;
+}
+/* line 54, ../sass/_quotes.scss */
+.perts-quote_credit.credit--top {
+  margin-top: 0px;
+  margin-bottom: 20px;
+}
+
+/* line 32, ../sass/qualtrics.scss */
+html #SurveyEngineBody {
+  background: none;
+  background-color: #e3e3e3;
+  font-family: "museo-sans", "Arial", sans-serif;
+  color: #333;
+}
+
+/* line 39, ../sass/qualtrics.scss */
+.SkinInner {
+  width: 100%;
+  background-color: #fff;
+  margin: 0px;
+}
+
+/* line 45, ../sass/qualtrics.scss */
+.hidden-label {
+  visibility: hidden;
+  height: 0;
+}
+
+/* line 50, ../sass/qualtrics.scss */
+.Skin {
+  background-color: #fff;
+}
+/* line 53, ../sass/qualtrics.scss */
+.Skin .Separator {
+  margin: 0;
+  /* viper: the negative margin was causing overlapping text */
+  /* margin-bottom: -30px; */
+  background-color: transparent;
+}
+/* line 59, ../sass/qualtrics.scss */
+.Skin .Separator ~ .Separator {
+  background-color: transparent;
+}
+/* line 64, ../sass/qualtrics.scss */
+.Skin #Logo,
+.Skin #PushStickyFooter,
+.Skin #Plug {
+  display: none !important;
+}
+/* line 70, ../sass/qualtrics.scss */
+.Skin #Plug {
+  background-color: #e3e3e3;
+  position: absolute;
+  left: -9999px;
+}
+/* line 76, ../sass/qualtrics.scss */
+.Skin #Header {
+  position: relative;
+  display: block;
+  padding: 0px;
+  height: 80px;
+  background-color: #3faeec;
+}
+/* line 84, ../sass/qualtrics.scss */
+.Skin #Footer {
+  background-color: #e3e3e3;
+  height: 80px;
+}
+/* line 88, ../sass/qualtrics.scss */
+.Skin #Footer .foot-text {
+  padding-top: 26px;
+  text-align: center;
+  font-family: "din-condensed-web", "Arial", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 18px;
+  color: #999;
+}
+/* line 99, ../sass/qualtrics.scss */
+.Skin div#Questions {
+  padding: 0px;
+  min-height: 400px;
+  overflow: initial;
+}
+/* line 105, ../sass/qualtrics.scss */
+.Skin .QuestionOuter {
+  padding: 0px;
+  overflow-x: auto;
+  -ms-overflow-x: auto;
+  -ms-overflow-style: auto;
+}
+/* line 111, ../sass/qualtrics.scss */
+.Skin .QuestionOuter .Inner {
+  padding: 0px;
+  /* Prevent wide content from scrolling, and prevent horiz scrollbar */
+  overflow-x: hidden;
+}
+/* line 119, ../sass/qualtrics.scss */
+.Skin #ProgressBar {
+  display: none;
+}
+/* line 123, ../sass/qualtrics.scss */
+.Skin .QuestionText {
+  padding: 0;
+  /* viper: solve overlapping text */
+  line-height: normal;
+}
+/* line 129, ../sass/qualtrics.scss */
+.Skin .QuestionBody,
+.Skin .MC .QuestionText,
+.Skin .TE .QuestionText,
+.Skin .Matrix .QuestionText {
+  display: block;
+  width: 770px;
+  margin: 0 auto;
+  padding: 0;
+  position: relative;
+}
+@media only screen and (max-width: 800px) {
+  /* line 129, ../sass/qualtrics.scss */
+  .Skin .QuestionBody,
+  .Skin .MC .QuestionText,
+  .Skin .TE .QuestionText,
+  .Skin .Matrix .QuestionText {
+    width: 100%;
+    padding: 0px 15px;
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+}
+/* line 153, ../sass/qualtrics.scss */
+.Skin .Matrix caption.QuestionText {
+  display: none;
+}
+/* line 157, ../sass/qualtrics.scss */
+.Skin .QuestionText {
+  margin: 0px;
+}
+/* line 161, ../sass/qualtrics.scss */
+.Skin .QuestionBody table.ChoiceStructure.narrow-table {
+  width: 300px;
+  margin-top: 25px;
+}
+/* line 166, ../sass/qualtrics.scss */
+.Skin .QuestionBody table.ChoiceStructure.narrow-table td {
+  padding: 12px 0;
+}
+/* line 171, ../sass/qualtrics.scss */
+.Skin .MC .QuestionBody {
+  margin: 20px auto 25px auto;
+}
+/* line 174, ../sass/qualtrics.scss */
+.Skin .MC .QuestionBody .LabelWrapper label {
+  vertical-align: middle;
+}
+/* line 179, ../sass/qualtrics.scss */
+.Skin .MC .QuestionText {
+  font-weight: 300;
+  font-size: 21px;
+  color: #333;
+}
+/* line 185, ../sass/qualtrics.scss */
+.Skin .MC table {
+  margin-bottom: 55px;
+}
+/* line 189, ../sass/qualtrics.scss */
+.Skin .MC input.TextEntryBox.InputText {
+  left: 0px;
+  margin: 5px 0px 15px 0px;
+}
+/* line 195, ../sass/qualtrics.scss */
+.Skin .ML *,
+.Skin .SL * {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+/* line 200, ../sass/qualtrics.scss */
+.Skin .ML .ChoiceStructure,
+.Skin .SL .ChoiceStructure.ChoiceStructureStyled {
+  background-color: #3faeec;
+  padding: 35px 6px 6px 6px;
+  margin: 30px 0px;
+  position: relative;
+}
+/* line 208, ../sass/qualtrics.scss */
+.Skin .ML .ChoiceStructure textarea,
+.Skin .SL .ChoiceStructure.ChoiceStructureStyled input {
+  width: 100% !important;
+  height: 250px !important;
+  border: 0;
+  outline: 0;
+  padding: 15px;
+  font-size: 21px;
+  font-weight: 300;
+  color: #333;
+  line-height: 28px;
+  background-color: #fff;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+}
+/* line 224, ../sass/qualtrics.scss */
+.Skin .SL .ChoiceStructure.ChoiceStructureStyled input {
+  height: 50px !important;
+  margin: 0px;
+}
+/* line 229, ../sass/qualtrics.scss */
+.Skin h2 {
+  font-size: 20px;
+  line-height: 1em;
+}
+/* line 233, ../sass/qualtrics.scss */
+.Skin p {
+  margin: 25px 0;
+}
+
+/* line 238, ../sass/qualtrics.scss */
+li span.LabelWrapper {
+  font-weight: 300;
+  font-size: 21px;
+  color: #333;
+}
+
+/* line 244, ../sass/qualtrics.scss */
+table span.LabelWrapper {
+  font-weight: 500;
+  font-size: 15px;
+  color: #333;
+  padding: 0px 10px;
+  margin: 0;
+  display: block;
+}
+
+/* line 253, ../sass/qualtrics.scss */
+.open-response_header {
+  position: absolute;
+  top: 12px;
+  left: 10px;
+  color: #fff;
+}
+
+/* Text formatting */
+/* line 262, ../sass/qualtrics.scss */
+#section-header {
+  text-align: center;
+  padding: 0px 0px 45px 0;
+  margin-top: 30px;
+  color: #999;
+  font-size: 18px;
+  font-family: "din-condensed-web", "Arial", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+}
+
+/* line 273, ../sass/qualtrics.scss */
+.Skin h1,
+.Skin #title-text {
+  color: #4593d5;
+  font-size: 24px;
+  margin-bottom: 30px;
+  font-weight: 700;
+}
+
+/* line 281, ../sass/qualtrics.scss */
+.Skin p {
+  font-size: 21px;
+  line-height: 30px;
+  margin: 15px 0px;
+  font-weight: 300;
+}
+
+/* line 288, ../sass/qualtrics.scss */
+.callout-text {
+  font-size: 21px;
+  line-height: 30px;
+  font-style: italic;
+  color: #4593d5;
+  margin: 30px 0px;
+  font-weight: 500;
+}
+
+/* line 297, ../sass/qualtrics.scss */
+.instruction-text {
+  font-size: 18px;
+  color: #999;
+  font-style: italic;
+  margin-bottom: 25px;
+}
+
+/* line 304, ../sass/qualtrics.scss */
+.footnote-text {
+  font-size: 14px;
+  color: #999;
+  margin-bottom: 25px;
+}
+
+/* Setting up custom containers */
+/* line 312, ../sass/qualtrics.scss */
+#main-content *,
+#split-page *,
+#splash-page * {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 318, ../sass/qualtrics.scss */
+#main-content,
+#splash-page {
+  display: block;
+  width: 800px;
+  padding: 0px 15px;
+  /* viper: was adding too much space to shorter questions, doesn't seem needed */
+  /* min-height: 450px; */
+  margin: 0 auto 20px auto;
+  max-width: 100%;
+  position: relative;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 332, ../sass/qualtrics.scss */
+#splash-page {
+  margin: 100px auto 20px auto;
+  text-align: center;
+}
+/* line 336, ../sass/qualtrics.scss */
+#splash-page h1 {
+  font-size: 32px;
+}
+
+/* line 343, ../sass/qualtrics.scss */
+#split-page {
+  display: block;
+  width: 1000px;
+  margin: 0px auto;
+  position: relative;
+  max-width: 100%;
+  padding: 0 0 0 15px;
+}
+/* line 351, ../sass/qualtrics.scss */
+#split-page:before, #split-page:after {
+  display: table;
+  content: " ";
+  clear: both;
+}
+
+/* line 359, ../sass/qualtrics.scss */
+#split-text,
+#split-image {
+  min-height: 1px;
+  position: relative;
+  float: left;
+  vertical-align: top;
+  max-width: 100%;
+  width: 50%;
+}
+
+/* line 369, ../sass/qualtrics.scss */
+#split-text {
+  padding: 0px 30px 0 0;
+  position: relative;
+}
+
+/* line 374, ../sass/qualtrics.scss */
+#split-image {
+  height: 680px;
+  overflow: hidden;
+}
+/* line 378, ../sass/qualtrics.scss */
+#split-image .image-block {
+  margin: 0px;
+}
+/* line 382, ../sass/qualtrics.scss */
+#split-image .image-caption {
+  position: absolute;
+  text-align: center;
+  bottom: 0px;
+  width: 100%;
+  height: 95px;
+  color: #999;
+  font-size: 18px;
+  font-style: italic;
+}
+
+@media only screen and (max-width: 767px) {
+  /* line 395, ../sass/qualtrics.scss */
+  #split-page {
+    padding: 0;
+  }
+
+  /* line 399, ../sass/qualtrics.scss */
+  #split-text,
+  #split-image {
+    display: block;
+    float: none;
+    width: 100%;
+  }
+
+  /* line 406, ../sass/qualtrics.scss */
+  #split-text {
+    padding: 0 15px;
+  }
+}
+@media (max-width: 500px) {
+  /* line 412, ../sass/qualtrics.scss */
+  .Skin .QuestionBody .ControlContainer {
+    /* viper: hide duplicate input on mobile */
+    display: none;
+  }
+}
+/* Hidden container */
+/* line 421, ../sass/qualtrics.scss */
+.hidden-container.hidden-container--hidden {
+  display: none;
+}
+
+/* Custom bullet lists */
+/* line 429, ../sass/qualtrics.scss */
+.Skin ul.perts-bullets,
+.Skin ol.perts-bullets {
+  margin-top: 20px;
+  margin-bottom: 20px;
+}
+/* line 434, ../sass/qualtrics.scss */
+.Skin ul.perts-bullets li,
+.Skin ol.perts-bullets li {
+  font-size: 21px;
+  line-height: 30px;
+  color: #666;
+  list-style: none;
+  margin-bottom: 3px;
+  font-weight: 300;
+  position: relative;
+}
+/* line 445, ../sass/qualtrics.scss */
+.Skin ul.perts-bullets,
+.Skin ul.perts-bullets li,
+.Skin .QuestionText ul.perts-bullets,
+.Skin .QuestionText ul.perts-bullets li {
+  list-style-type: none;
+  /* viper: custom li bullets appear in iPhone 6 Safari */
+  position: relative;
+}
+/* line 454, ../sass/qualtrics.scss */
+.Skin ul.perts-bullets li:before {
+  content: "";
+  height: 12px;
+  width: 12px;
+  background-color: #3faeec;
+  -moz-border-radius: 6px;
+  -webkit-border-radius: 6px;
+  border-radius: 6px;
+  position: absolute;
+  display: block;
+  margin-top: 8px;
+  left: -30px;
+}
+
+/* User input fields (open-response and short-form) */
+/* line 472, ../sass/qualtrics.scss */
+.Skin .open-response {
+  background-color: #3faeec;
+  margin: 20px 0px;
+  padding: 15px;
+}
+/* line 477, ../sass/qualtrics.scss */
+.Skin .open-response .open-response_header {
+  color: #fff;
+  padding-bottom: 15px;
+}
+/* line 482, ../sass/qualtrics.scss */
+.Skin .open-response textarea.open-response_input {
+  width: 100%;
+  height: 250px;
+  border: 0;
+  outline: 0;
+  padding: 15px;
+  font-size: 21px;
+  font-weight: 300;
+  color: #333;
+  line-height: 28px;
+  background-color: #fff;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+}
+/* line 498, ../sass/qualtrics.scss */
+.Skin input.short-form,
+.Skin input[type="TEXT"] {
+  border-style: none;
+  border: 1px solid #ccc;
+  font-size: 21px;
+  font-weight: 300;
+  padding: 10px 15px;
+  margin: 0px;
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background-color: #fff;
+  -moz-border-radius: 0;
+  -webkit-border-radius: 0;
+  border-radius: 0;
+}
+/* line 514, ../sass/qualtrics.scss */
+.Skin input[type="TEXT"] {
+  margin-bottom: 20px;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+/* line 523, ../sass/qualtrics.scss */
+.Skin .MC input[type="TEXT"], .Skin .SL input[type="TEXT"] {
+  border: 1px solid #ccc;
+}
+
+/* Hide timing questions during previews so they look more realistic. */
+/* line 530, ../sass/qualtrics.scss */
+.QuestionOuter.Timing {
+  display: none;
+}
+
+/* Fixes for iPhone and iPad */
+@media only screen and (max-device-width: 1024px) and (min-device-width: 768px) {
+  /* Qualtrics applies a 90% max width here. Stupid. */
+  /* line 537, ../sass/qualtrics.scss */
+  html #SurveyEngineBody.iOS .Skin .SkinInner,
+  html #SurveyEngineBody.Android .Skin .SkinInner {
+    max-width: 100%;
+  }
+}
+/* Adjust placement of fake radio buttons for mobile. */
+/* line 544, ../sass/qualtrics.scss */
+#SurveyEngineBody.iOS .Skin .MC li input[type="radio"]::before {
+  top: -4px;
+  left: -4px;
+}
+
+/* line 548, ../sass/qualtrics.scss */
+#SurveyEngineBody.iOS .Skin .MC li input[type="checkbox"]::before,
+#SurveyEngineBody.iOS .Skin .MC li input[type="checkbox"]:checked::before {
+  top: -2px;
+}
+
+/* line 552, ../sass/qualtrics.scss */
+#SurveyEngineBody.iOS .Skin .MC .QuestionBody .LabelWrapper label,
+#SurveyEngineBody.Android .Skin .MC .QuestionBody .LabelWrapper label {
+  width: 70%;
+  margin-left: 10px;
+}
+
+/* Override user agent stylesheets on mobile to allow scrolling within
+ * fieldset elements */
+/* line 560, ../sass/qualtrics.scss */
+fieldset {
+  min-width: 0;
+}
+
+@-moz-document url-prefix() {
+  /* line 565, ../sass/qualtrics.scss */
+  fieldset {
+    display: table-cell;
+  }
+}
+/* line 574, ../sass/qualtrics.scss */
+.ExportTags {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}

--- a/sass/qualtrics.scss
+++ b/sass/qualtrics.scss
@@ -566,3 +566,18 @@ fieldset {
         display: table-cell;
     }
 }
+
+// Only display ExportTags on screen readers. Why? Qualtrics "Check
+// Accessibility Tool" recommends enabling export tags, but we don't want them
+// to show for all viewers. The following style rule is adapted from Bootstrap's
+// sr-only (screen reader only) rule.
+.ExportTags {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}


### PR DESCRIPTION
This change hides Qualtrics content with class `ExportTags` for all users except those using screen readers.

Why? Qualtrics "Check Accessibility Tool" recommends enabling export tags, but we don't want them to show for all viewers. The following style rule is adapted from Bootstrap's sr-only (screen reader only) rule.

## Test

I tested this by adding the rule directly into Qualtrics "Look & Feel" advanced box.