### PR TITLE
Fix class spelling error

### DIFF
--- a/css/qualtrics.css
+++ b/css/qualtrics.css
@@ -1348,7 +1348,7 @@ fieldset {
   }
 }
 /* line 574, ../sass/qualtrics.scss */
-.ExportTags {
+.ExportTag {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/sass/qualtrics.scss
+++ b/sass/qualtrics.scss
@@ -571,7 +571,7 @@ fieldset {
 // Accessibility Tool" recommends enabling export tags, but we don't want them
 // to show for all viewers. The following style rule is adapted from Bootstrap's
 // sr-only (screen reader only) rule.
-.ExportTags {
+.ExportTag {
   position: absolute;
   width: 1px;
   height: 1px;


### PR DESCRIPTION
I'm unsure how I let this mistake in, since I copy/pasted the working code out of Qualtrics Look & Feel box, but here is a correction. I will also post the PR to update neptune.

<img width="452" alt="screen shot 2018-05-31 at 9 23 08 am" src="https://user-images.githubusercontent.com/276924/40794523-4e933874-64b4-11e8-8d65-27cffc85cb95.png">
