### PR TITLE
testing flag in cross_site.gif

### DIFF
--- a/js/qualtrics.js
+++ b/js/qualtrics.js
@@ -794,11 +794,17 @@ function PERTS_MODULE() {
 
   p.getPdUrl = function (key) {
     // For Neptune only!
+
+    // The testing flag is set by the Neptune Portal whenever someone bypasses
+    // readiness, e.g. by prefixing the participation code with "testing only".
+    // Record this state with any saved pd so we can filter it easily.
+    var testingParam = perts.data('testing') === 'true' ? '&testing=true' : '';
     var participantId = perts.data('participant_id');
     var surveyId = perts.data('survey_id');
     return perts.domain() + '/api/participants/' + participantId +
       '/data/cross_site.gif?survey_id=' + surveyId + '&' +
-      'key=' + key + '&value=' + encodeURIComponent(perts.data(key));
+      'key=' + key + '&value=' + encodeURIComponent(perts.data(key)) +
+      testingParam;
   };
 
   p.dataIsEmbedded = function (key) {


### PR DESCRIPTION
Addresses https://github.com/PERTS/neptune/issues/1024

Passes value of `testing` embedded datum to all pd being written. Then Neptune can take different action on testing and non-testing pd.

Requires that Qualtrics surveys have the embedded datum of this name configured, but this is already our convention; Research uses it to filter on their end.

## Testing

I hand-tested the `getPdUrl()` function in a js console. End-to-end testing in a dev deploy is coming up.