### PR TITLE
make .instruction-text high contrast

### DIFF
--- a/sass/qualtrics.scss
+++ b/sass/qualtrics.scss
@@ -302,10 +302,8 @@ table span.LabelWrapper {
     font-weight: 500;
 }
 
-.instruction-text {
-    font-size: 18px;
-    color: $light-font-color;
-    font-style: italic;
+.instruction-text, .Skin p.instruction-text {
+    font-weight: 500;
     margin-bottom: 25px;
 }
 


### PR DESCRIPTION
@arnrow reported that some students find the "instruction text" of our qualtrics theme to be too low-contrast. I agree. I also always felt that it was too easy to ignore, which doesn't match its purpose.

Here's my change, visually:

<img width="799" alt="Screen Shot 2019-04-03 at 9 55 29 AM" src="https://user-images.githubusercontent.com/15002798/55498647-ff995500-55f8-11e9-8810-d76b301a2e8b.png">

<img width="800" alt="Screen Shot 2019-04-03 at 10 00 32 AM" src="https://user-images.githubusercontent.com/15002798/55498667-04f69f80-55f9-11e9-9d7a-90f3e7e0c5d4.png">

## Testing

I opened a survey that uses this theme and used the dev tools to remove the existing `.instruction-text` block, then wrote a new one that created the screenshots.

## Todo

* [x] update neptune with this version of silk
