### PR TITLE
Add gitleaks script and config

### DIFF
--- a/gitleaks/gitleaks.sh
+++ b/gitleaks/gitleaks.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
-# Run gitleaks https://github.com/zricethezav/gitleaks
+
+# Run gitleaks from any of our repositories with the following commands:
+#    /bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/PERTS/silk/HEAD/gitleaks/gitleaks.sh)\"
+
+# You probably also want to add the following to your .gitignore file:
+#    gitleaks*
+
+# More about gitleaks: https://github.com/zricethezav/gitleaks
 
 # Lines which have an error cause this whole script to exit with an error.
 # http://stackoverflow.com/questions/3474526/stop-on-first-error
@@ -20,13 +27,15 @@ if [ "$CI" = "true" ]; then
   export GITLEAKS_BINARY="https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_RELEASE}/gitleaks-linux-amd64"
 fi
 
+# Download the gitleaks binary if it hasn't already been downloaded.
 if ! [ -f ./${GITLEAKS_CMD} ]; then
   echo "[gitleaks] Downloading gitleaks binary."
   curl -o ${GITLEAKS_CMD} -L ${GITLEAKS_BINARY}
   chmod +x ${GITLEAKS_CMD}
 fi
 
-
+# To ensure we're always using the latest gitleaks rules/config file, redownload
+# the latest version from this repo.
 echo "[gitleaks] Downloading gitleaks config."
 curl -o gitleaks.toml -L ${GITLEAKS_CONFIG}
 

--- a/gitleaks/gitleaks.sh
+++ b/gitleaks/gitleaks.sh
@@ -15,7 +15,7 @@ set -e
 # Find gitleaks releases here: https://github.com/zricethezav/gitleaks/releases
 export GITLEAKS_RELEASE="7.2.2"
 export GITLEAKS_CMD="gitleaks-${GITLEAKS_RELEASE}"
-export GITLEAKS_CONFIG="https://raw.githubusercontent.com/PERTS/silk/ttd-gitleaks/gitleaks/gitleaks.toml"
+export GITLEAKS_CONFIG="https://raw.githubusercontent.com/PERTS/silk/HEAD/gitleaks/gitleaks.toml"
 
 # Binary for local/mac development environment
 export GITLEAKS_BINARY="https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_RELEASE}/gitleaks-darwin-amd64"

--- a/gitleaks/gitleaks.sh
+++ b/gitleaks/gitleaks.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Run gitleaks https://github.com/zricethezav/gitleaks
+
+# Lines which have an error cause this whole script to exit with an error.
+# http://stackoverflow.com/questions/3474526/stop-on-first-error
+set -e
+
+# Find gitleaks releases here: https://github.com/zricethezav/gitleaks/releases
+export GITLEAKS_RELEASE="7.2.2"
+export GITLEAKS_CMD="gitleaks-${GITLEAKS_RELEASE}"
+export GITLEAKS_CONFIG="https://raw.githubusercontent.com/PERTS/silk/ttd-gitleaks/gitleaks/gitleaks.toml"
+
+# Binary for local/mac development environment
+export GITLEAKS_BINARY="https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_RELEASE}/gitleaks-darwin-amd64"
+
+if [ "$CI" = "true" ]; then
+  echo "[gitleaks] Running in CI mode."
+
+  # Override with Codeship/Docker binary
+  export GITLEAKS_BINARY="https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_RELEASE}/gitleaks-linux-amd64"
+fi
+
+if ! [ -f ./${GITLEAKS_CMD} ]; then
+  echo "[gitleaks] Downloading gitleaks binary."
+  curl -o ${GITLEAKS_CMD} -L ${GITLEAKS_BINARY}
+  chmod +x ${GITLEAKS_CMD}
+fi
+
+
+echo "[gitleaks] Downloading gitleaks config."
+curl -o gitleaks.toml -L ${GITLEAKS_CONFIG}
+
+echo "[gitleaks] Scanning..."
+./${GITLEAKS_CMD} --config-path=gitleaks.toml  --path=./ --no-git -v

--- a/gitleaks/gitleaks.toml
+++ b/gitleaks/gitleaks.toml
@@ -1,0 +1,180 @@
+# Shared .gitleaks.toml file used all repositories.
+title = "gitleaks config"
+
+[[rules]]
+	description = "AWS Access Key"
+	regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+	tags = ["key", "AWS"]
+
+[[rules]]
+	description = "AWS Secret Key"
+	regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
+	tags = ["key", "AWS"]
+
+[[rules]]
+	description = "AWS MWS key"
+	regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+	tags = ["key", "AWS", "MWS"]
+
+[[rules]]
+	description = "Facebook Secret Key"
+	regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+	tags = ["key", "Facebook"]
+
+[[rules]]
+	description = "Facebook Client ID"
+	regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+	tags = ["key", "Facebook"]
+
+[[rules]]
+	description = "Twitter Secret Key"
+	regex = '''(?i)twitter(.{0,20})?[0-9a-z]{35,44}'''
+	tags = ["key", "Twitter"]
+
+[[rules]]
+	description = "Twitter Client ID"
+	regex = '''(?i)twitter(.{0,20})?[0-9a-z]{18,25}'''
+	tags = ["client", "Twitter"]
+
+[[rules]]
+	description = "Github"
+	regex = '''(?i)github(.{0,20})?(?-i)[0-9a-zA-Z]{35,40}'''
+	tags = ["key", "Github"]
+
+[[rules]]
+	description = "LinkedIn Client ID"
+	regex = '''(?i)linkedin(.{0,20})?(?-i)[0-9a-z]{12}'''
+	tags = ["client", "LinkedIn"]
+
+[[rules]]
+	description = "LinkedIn Secret Key"
+	regex = '''(?i)linkedin(.{0,20})?[0-9a-z]{16}'''
+	tags = ["secret", "LinkedIn"]
+
+[[rules]]
+	description = "Slack"
+	regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+	tags = ["key", "Slack"]
+
+[[rules]]
+	description = "Asymmetric Private Key"
+	regex = '''-----BEGIN ((EC|PGP|DSA|RSA|OPENSSH) )?PRIVATE KEY( BLOCK)?-----'''
+	tags = ["key", "AsymmetricPrivateKey"]
+  [rules.allowlist]
+    description = "Development Private Key"
+    regexes = ['''^default_jwt_secret_rsa = \'\'\'-----BEGIN RSA PRIVATE KEY-----''']
+
+[[rules]]
+	description = "Google API key"
+	regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+	tags = ["key", "Google"]
+  
+[[rules]]
+	description = "Google (GCP) Service Account"
+	regex = '''"type": "service_account"'''
+	tags = ["key", "Google"]
+  [rules.allowlist]
+    description = "Comment describing usage"
+    regexes = ['''#     "type": "service_account",''']
+
+[[rules]]
+	description = "Heroku API key"
+	regex = '''(?i)heroku(.{0,20})?[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+	tags = ["key", "Heroku"]
+
+[[rules]]
+	description = "MailChimp API key"
+	regex = '''(?i)(mailchimp|mc)(.{0,20})?[0-9a-f]{32}-us[0-9]{1,2}'''
+	tags = ["key", "Mailchimp"]
+
+[[rules]]
+	description = "Mailgun API key"
+	regex = '''((?i)(mailgun|mg)(.{0,20})?)?key-[0-9a-z]{32}'''
+	tags = ["key", "Mailgun"]
+
+[[rules]]
+	description = "PayPal Braintree access token"
+	regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
+	tags = ["key", "Paypal"]
+
+[[rules]]
+	description = "Picatic API key"
+	regex = '''sk_live_[0-9a-z]{32}'''
+	tags = ["key", "Picatic"]
+
+[[rules]]
+	description = "SendGrid API Key"
+	regex = '''SG\.[\w_]{16,32}\.[\w_]{16,64}'''
+	tags = ["key", "SendGrid"]
+
+[[rules]]
+	description = "Slack Webhook"
+	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+	tags = ["key", "slack"]
+
+[[rules]]
+	description = "Stripe API key"
+	regex = '''(?i)stripe(.{0,20})?[sr]k_live_[0-9a-zA-Z]{24}'''
+	tags = ["key", "Stripe"]
+
+[[rules]]
+	description = "Square access token"
+	regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
+	tags = ["key", "square"]
+
+[[rules]]
+	description = "Square OAuth secret"
+	regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+	tags = ["key", "square"]
+
+[[rules]]
+	description = "Twilio API key"
+	regex = '''(?i)twilio(.{0,20})?SK[0-9a-f]{32}'''
+	tags = ["key", "twilio"]
+
+[[rules]]
+	description = "Dynatrace ttoken"
+	regex = '''dt0[a-zA-Z]{1}[0-9]{2}\.[A-Z0-9]{24}\.[A-Z0-9]{64}'''
+	tags = ["key", "Dynatrace"]
+
+[[rules]]
+	description = "Shopify shared secret"
+	regex = '''shpss_[a-fA-F0-9]{32}'''
+	tags = ["key", "Shopify"]
+
+[[rules]]
+	description = "Shopify access token"
+	regex = '''shpat_[a-fA-F0-9]{32}'''
+	tags = ["key", "Shopify"]
+
+[[rules]]
+	description = "Shopify custom app access token"
+	regex = '''shpca_[a-fA-F0-9]{32}'''
+	tags = ["key", "Shopify"]
+
+[[rules]]
+	description = "Shopify private app access token"
+	regex = '''shppa_[a-fA-F0-9]{32}'''
+	tags = ["key", "Shopify"]
+
+[allowlist]
+  description = "Global allowlist files"
+  paths = [
+    # Python Libraries
+    '''lib''',
+    # NPM Modules
+    '''node_modules''',
+  ]
+	files = [
+    # gitleaks binary
+		'''^gitleaks-[0-9\.]+$''',
+    # gitleaks config
+    '''^\.?gitleaks.toml$''',
+	  '''(.*?)(png|jpg|gif|doc|docx|pdf|bin|xls|pyc|zip)$''',
+	  '''(go.mod|go.sum)$''',
+  ]
+  regexes = [
+    # neptune: Hard-coded so localhost works.
+    # Key is limited by http referrer to localhost:8080/* and localhost:8888/*.
+  	'''AIzaSyCJMqfce0WDD1rW9ZleUwDUwasXzQVIwGo'''
+  ]


### PR DESCRIPTION
## Background

Re https://github.com/PERTS/triton/issues/1944

We discussed how it's going to be immediately annoying to have to maintain individual gitleaks rules/config file across all of our repositories. This PR allows us to maintain our gitleaks work, mostly, in a single place.

This PR will allow updates to this repo's `gitleaks.toml` config file to be available to all consuming repos, [within 5 minutes](https://stackoverflow.com/a/55615178) after changes are merged.

## Implementation

- Created a `gitleaks/gitleak.sh` script
- Created a `gitleaks/gitleaks.toml` config

This allows us to run the following command to scan with gitleaks:

```
/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/PERTS/silk/HEAD/gitleaks/gitleaks.sh)\"
```

We can then add an `npm run gitleaks` npm script like this:

```
"script": {
  "gitleaks": "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/PERTS/silk/HEAD/gitleaks/gitleaks.sh)\""
```

And this script handles downloading the appropriate local/mac gitleaks binary or the linux binary for Codeship/Docker builds.

```
  CI=true npm run gitleaks
```

## Pre-Merge

- [ ] Update `gitleaks.sh` with the following line. It's currently using the feature branch for testing.

```diff
-  export GITLEAKS_CONFIG="https://raw.githubusercontent.com/PERTS/silk/ttd-gitleaks/gitleaks/gitleaks.toml"
+  export GITLEAKS_CONFIG="https://raw.githubusercontent.com/PERTS/silk/HEAD/gitleaks/gitleaks.toml"
```

## Post-Deployment

- [x] Update consuming repos to run script from HEAD instead of `ttd-gitleaks`.
- [x] Test consuming repos scan and build properly.