### PR TITLE
ignore dirs: data, secrets

### DIFF
--- a/gitleaks/gitleaks.toml
+++ b/gitleaks/gitleaks.toml
@@ -175,6 +175,11 @@ title = "gitleaks config"
     '''webtest''',
     # NPM Modules
     '''node_modules''',
+    # These are safe/allowed places to store things that
+    # gitleaks would otherwise flag because dirs with these names
+    # MUST be ignored by all consuming projects.
+    '''data''',
+    '''secrets''',
   ]
 	files = [
     # gitleaks binary


### PR DESCRIPTION
## Background

Closes #25 

## Implementation

Decided on two different dir names because these kinds of files seem pretty different: `data/` for other people's info we're keeping safe and `secrets/` for keys and passwords we use internally.

## Pre-deployment

Add these dirs to the `.gitignore` of each repo that uses gitleaks before this is merged:

* [x] triton
* [x] neptune
* [x] rserve
* [x] saturn