### PR TITLE
feat: exclude GitHub public ssh key

### DIFF
--- a/gitleaks/gitleaks.toml
+++ b/gitleaks/gitleaks.toml
@@ -197,5 +197,7 @@ title = "gitleaks config"
   regexes = [
     # neptune: Hard-coded so localhost works.
     # Key is limited by http referrer to localhost:8080/* and localhost:8888/*.
-  	'''AIzaSyCJMqfce0WDD1rW9ZleUwDUwasXzQVIwGo'''
+  	'''AIzaSyCJMqfce0WDD1rW9ZleUwDUwasXzQVIwGo''',
+	# Exclude GitHub Public SSH Key
+	'''github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjsh'''
   ]


### PR DESCRIPTION
- Re https://github.com/PERTS/canvas-lms/issues/27
- In order to pass a gitleaks check, we need to include the GitHub public ssh key.